### PR TITLE
Add Dockerfile for containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:25-alpine
+
+WORKDIR /app
+
+COPY package.json .
+
+RUN npm install --ignore-scripts
+
+RUN npm i -g serve
+
+COPY . .
+
+RUN npm run build
+
+# Default port for serve (https://www.npmjs.com/package/serve)
+EXPOSE 3000
+
+CMD [ "serve", "-s", "dist" ]


### PR DESCRIPTION
### Summary / Description

Added a `Dockerfile` for containerizing the frontend. It uses the npm package [serve](https://www.npmjs.com/package/serve) to serve the static site.

**Related Issues:** #4 
#### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [ ] Documentation update

#### Test Evidence

Describe how this PR has been tested.

- [ ] Unit tests
- [ ] Integration tests

#### Questions / Discussion Points

N/A