### PR TITLE
Set up authContext

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,44 +1,18 @@
-import { useState } from 'react';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
 import './App.css';
-import { Button, Container, Row, Col } from 'react-bootstrap';
+import { useAuthContext } from './contexts/AuthContext.js';
 
 function App() {
-  const [count, setCount] = useState(0);
+  const { isLoggedIn } = useAuthContext();
 
   return (
     <>
-      <h1>React Bootstrap Button</h1>
-      <Button>I am a bootstrap button</Button>
-      <div>
-        <a
-          href="https://vite.dev"
-          target="_blank">
-          <img
-            src={viteLogo}
-            className="logo"
-            alt="Vite logo"
-          />
-        </a>
-        <a
-          href="https://react.dev"
-          target="_blank">
-          <img
-            src={reactLogo}
-            className="logo react"
-            alt="React logo"
-          />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
+      {isLoggedIn ? (
+        // TODO: Replace with actual logged-in content
+        <h2>Logged In</h2>
+      ) : (
+        // TODO: Replace with actual logged-out content
+        <h2>Not Logged In</h2>
+      )}
     </>
   );
 }

--- a/src/contexts/AuthContext.js
+++ b/src/contexts/AuthContext.js
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+export const AuthContext = createContext();
+
+export const useAuthContext = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuthContext must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+import { AuthContext } from './AuthContext';
+
+export const AuthProvider = ({ children }) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [user, setUser] = useState(null);
+
+  return (
+    <AuthContext.Provider value={{ isLoggedIn, setIsLoggedIn, user, setUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,9 +4,12 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import './index.css';
 import App from './App.jsx';
+import { AuthProvider } from './contexts/AuthProvider.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
### Summary / Description

Add a global authentication state to manage logged in state. The idea here is that API components will hook into the context and set the log-in state to false whenever we get a 401. 

Note: The context is split into 2 files to avoid the warning: `react-refresh/only-export-components` which is to ensure React's fast refresh feature keeps working properly

_Yes, I named the branch wrong, it should be 14, not 4_

**Related Issues:** #14 

#### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [ ] Documentation update

#### Test Evidence

Loading up the main page shows "Not Logged In" as expected

- [ ] Unit tests
- [ ] Integration tests

#### Questions / Discussion Points

Please discuss if you disagree with this format of doing things. I expect this will set a precedent for how we manage contexts in the app in the future.