### PR TITLE
Change show password button to primary colour

### DIFF
--- a/src/components/common/ShowPasswordButton.jsx
+++ b/src/components/common/ShowPasswordButton.jsx
@@ -6,7 +6,7 @@ import styles from '../styling/common/ShowPasswordButton.module.css';
 const ShowPasswordButton = ({ isShowingPassword, isLoading, onClick }) => {
   return (
     <Button
-      variant="outline-secondary"
+      variant="outline-primary"
       onClick={onClick}
       disabled={isLoading}
       className={styles.passwordToggleButton}>


### PR DESCRIPTION
### Summary / Description

Changes the colour of the show password button icon to be primary, to make it cohesive with the rest of the UI. See the issue (#62) for screenshot comparison.

Note that this uses the new styling, and so should be merged after #60 

**Related Issues:** #62 

#### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [ ] Documentation update

#### Test Evidence

N/A

- [ ] Unit tests
- [ ] Integration tests

#### Questions / Discussion Points

N/A