### PR TITLE
Proper auth state propagation

### DIFF
--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -1,18 +1,25 @@
 import { AuthContext } from './AuthContext';
 import { setAuthFailedCallback } from '../api/api';
+import { useEffect, useState } from 'react';
 
 export const AuthProvider = ({ children }) => {
-  const isLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
+  const storedLoginStatus = localStorage.getItem('isLoggedIn') === 'true';
+  const [isLoggedIn, setIsLoggedIn] = useState(storedLoginStatus);
 
-  const setIsLoggedIn = (value) => {
+  useEffect(() => {
+    setAuthFailedCallback(() => {
+      setIsLoggedIn(false);
+    });
+  }, []);
+
+  const setIsLoggedInWrapper = (value) => {
+    setIsLoggedIn(value);
     localStorage.setItem('isLoggedIn', value);
   };
 
-  setAuthFailedCallback(() => {
-    setIsLoggedIn(false);
-  });
-
   return (
-    <AuthContext.Provider value={{ isLoggedIn, setIsLoggedIn }}>{children}</AuthContext.Provider>
+    <AuthContext.Provider value={{ isLoggedIn, setIsLoggedIn: setIsLoggedInWrapper }}>
+      {children}
+    </AuthContext.Provider>
   );
 };


### PR DESCRIPTION
### Summary / Description

Previously logging in did not automatically redirect the user to the homepage using the protected/unprotected routes. This fixes that, with one caveat.

If the user logs out on one tab, that won't be reflected in other open tabs until they are refreshed (or vis versa for logging in).

**Related Issues:** #79 

#### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [ ] Documentation update

#### Test Evidence

Tried logging in/out and was properly redirected

#### Questions / Discussion Points

N/A