### PR TITLE
Add error mapping to account page

### DIFF
--- a/src/pages/AccountPage.jsx
+++ b/src/pages/AccountPage.jsx
@@ -15,6 +15,7 @@ const changePasswordErrorMappings = {
   EMAIL_NOT_REGISTERED: 'Invalid session. Please sign out and sign back in',
   ACCOUNT_NOT_ACTIVATED: 'Invalid session. Please sign out and sign back in',
   INVALID_EMAIL_OR_PASSWORD: 'Incorrect password entered',
+  NEW_PASSWORD_SAME_WITH_OLD_PASSWORD: 'New password cannot be the same as the old password',
 };
 
 const AccountPage = () => {


### PR DESCRIPTION
### Summary / Description

Adds a mapping to `AccountPage.jsx` for `NEW_PASSWORD_SAME_WITH_OLD_PASSWORD` which will be added in [#133](https://github.com/Co-App-Team/backend/pull/133)

**Related Issues:** #99 

#### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [ ] Documentation update

#### Test Evidence

This has been tested against the branch from [#133](https://github.com/Co-App-Team/backend/pull/133)

#### Questions / Discussion Points

N/A