### PR TITLE
Allow users to add/edit interview datetime 

### DIFF
--- a/src/components/calendar/CalendarInterviewModal.jsx
+++ b/src/components/calendar/CalendarInterviewModal.jsx
@@ -20,7 +20,6 @@ function CalendarInterviewModal({ onShow, onHide, applications, onSaved }) {
 
   const handleSelectedApplication = async (e) => {
     const selected = e.value;
-    console.log('this is selected', selected);
     try {
       const result = await getCompanyCallback(selected?.companyId);
       const companyName = result?.company?.companyName;

--- a/src/components/jobApplications/JobApplicationCard.jsx
+++ b/src/components/jobApplications/JobApplicationCard.jsx
@@ -97,8 +97,16 @@ const JobApplicationCard = ({ jobApplication, onUpdated, setError, companies }) 
 
       await onUpdated();
 
+      const isAtInterviewStage =
+        (jobApplication.status === 'INTERVIEWING' ||
+          jobApplication.status === 'INTERVIEW_SCHEDULED') &&
+        (newStatus === 'INTERVIEWING' || newStatus === 'INTERVIEW_SCHEDULED');
+
       // prompt user to enter the interview's date and time
-      if (jobApplication.status !== 'INTERVIEWING' && newStatus === 'INTERVIEWING') {
+      if (
+        !isAtInterviewStage &&
+        (newStatus === 'INTERVIEW_SCHEDULED' || newStatus === 'INTERVIEWING')
+      ) {
         const updated = {
           ...finalFormData,
           status: newStatus,

--- a/src/components/jobApplications/JobApplicationModal.jsx
+++ b/src/components/jobApplications/JobApplicationModal.jsx
@@ -70,7 +70,10 @@ function JobApplicationModal({ onShow, onHide, companies, data, onSaved }) {
   };
 
   const validateInterviewDateTime = (date) => {
-    return formData.status !== 'INTERVIEWING' || (date && date.trim() !== '');
+    return (
+      (formData.status !== 'INTERVIEW_SCHEDULED' && formData.status !== 'INTERVIEWING') ||
+      (date && date.trim() !== '')
+    );
   };
 
   const validateNumPositions = (num) => {
@@ -286,7 +289,8 @@ function JobApplicationModal({ onShow, onHide, companies, data, onSaved }) {
               )}
 
               <FormGroup>
-                {formData.status === 'INTERVIEWING' && (
+                {(formData.status === 'INTERVIEW_SCHEDULED' ||
+                  formData.status === 'INTERVIEWING') && (
                   <>
                     <Form.Label>Interview Date and Time</Form.Label>
                     <Form.Control

--- a/src/pages/CalendarPage.jsx
+++ b/src/pages/CalendarPage.jsx
@@ -73,9 +73,9 @@ const Calendar = () => {
     const request = async () => {
       try {
         // only allow users to make interviews with applications
-        // that are not at the "interviewing" stage yet
+        // that are at either "not applied" or "applied" stage
         await getApplicationsCallback({
-          status: 'NOT_APPLIED,APPLIED,INTERVIEW_SCHEDULED',
+          status: 'NOT_APPLIED,APPLIED',
         });
       } catch (error) {
         const message = getErrorMessage(error, {});


### PR DESCRIPTION
### Summary / Description

This PR worked on allowing users to modify their interviews' date and time. 

If the user wishes to create a new job application:
1. If the status of the application is **not** interviewing, the interview datetime field is not shown
<img width="497" height="654" alt="image" src="https://github.com/user-attachments/assets/4cbd1cf8-7fd5-41e2-ae69-ae82815f448b" />

2.  If the status of the application is interviewing, the interview datetime field is shown
<img width="494" height="723" alt="image" src="https://github.com/user-attachments/assets/c0918eb8-5005-4541-bd26-637e797f90a3" />

- Clicking the _Submit_ button without entering the interview's date and time displays an error
<img width="499" height="751" alt="image" src="https://github.com/user-attachments/assets/110c91f4-846a-4ecc-8ad5-89a8f4b526f4" />


If the user changes the status of an application from a non-interviewing status to interviewing, the edit form will be displayed. 
<img width="1286" height="141" alt="image" src="https://github.com/user-attachments/assets/bfa77963-d5a7-458f-859a-71b159fa04d5" />
<img width="1402" height="710" alt="image" src="https://github.com/user-attachments/assets/6b93cd9a-debf-4cea-986b-9eb3a26ebe8b" />


**Related Issues:** #167 

#### Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [ ] Documentation update

#### Test Evidence
Created/modified job applications and checked that changes were made as intended.

#### Questions / Discussion Points
N/A